### PR TITLE
Disable ModVersionChecker due to error during init

### DIFF
--- a/src/bspkrs/bspkrscore/fml/bspkrsCoreMod.java
+++ b/src/bspkrs/bspkrscore/fml/bspkrsCoreMod.java
@@ -33,7 +33,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class bspkrsCoreMod implements IConnectionHandler
 {
     // config stuff
-    public boolean              allowUpdateCheck          = true;
+    public boolean              allowUpdateCheck          = false;
     public boolean              allowDebugOutput          = false;
     public int                  updateTimeoutMilliseconds = 3000;
     


### PR DESCRIPTION
java.lang.ArrayIndexOutOfBoundsException: 0 is generated at initialization

traces back to ModVersionChecker

presumably the link at versionURL being dead is the issue, but I'm not entirely sure

manually changing the mod's .cfg file will do the trick, but the default for allowUpdateCheck is true currently

could fix or thoroughly remove version control utility on these legacy versions, but it's been 9 years, so I'd call it good enough with this